### PR TITLE
Removed duplicate compost item.

### DIFF
--- a/RecyclingGame2D/Assets/Scenes/CompostMinigame.unity
+++ b/RecyclingGame2D/Assets/Scenes/CompostMinigame.unity
@@ -279,7 +279,7 @@ Transform:
   - {fileID: 1725891491}
   - {fileID: 725437551}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &187654862
 MonoBehaviour:
@@ -306,8 +306,8 @@ MonoBehaviour:
   - {x: 0.28627717, y: 0.36170882, z: 0}
   - {x: 0.311421, y: -0.4497123, z: 0}
   m_ShapePathHash: 724017967
-  m_Mesh: {fileID: 1894781401}
-  m_InstanceId: 27180
+  m_Mesh: {fileID: 1652705124}
+  m_InstanceId: 28212
 --- !u!1 &210910893
 GameObject:
   m_ObjectHideFlags: 0
@@ -374,7 +374,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &439326709
 PrefabInstance:
@@ -397,7 +397,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9095435295868412797, guid: 10cc8dffccac6374ea5dd98145ecd6f3, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 9095435295868412797, guid: 10cc8dffccac6374ea5dd98145ecd6f3, type: 3}
       propertyPath: m_AnchorMax.x
@@ -823,7 +823,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1157445448
 GameObject:
@@ -854,7 +854,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1170049980
 PrefabInstance:
@@ -1023,7 +1023,7 @@ RectTransform:
   - {fileID: 1788632989}
   - {fileID: 1374638410}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1795,6 +1795,170 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5557397954359504934, guid: fa9164754ee632a42b809e39a6a9d813, type: 3}
   m_PrefabInstance: {fileID: 1648643653}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &1652705124
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: -0.006286055, y: -0.044001743, z: 0}
+      m_Extent: {x: 0.31770706, y: 0.40571058, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010003000500040003000600050006000300070002000800000000000900030001000a00020004000b00010003000c00070005000d00040006000e00050007000f000600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 93729f3eb140e6be000000008fe07f3f09bafd3c000000800000008093729f3eb140e6be93729f3eb140e6beec92923ee631b93e00000000aaf8afbce0f07f3f0000008000000080ec92923ee631b93eec92923ee631b93ec002993e2c3b34bd000000008fe07f3f30bafd3c0000008000000080ec92923ee631b93e93729f3eb140e6be40fbcdbbc808e3be00000000b40ca2bc2ef37fbf000000000000008093729f3eb140e6be6de2a5beded0dfbe40fbcdbbfcf9b53e0000000073f8afbce0f07f3f0000008000000080c60299be13c2b23eec92923ee631b93ec60299be13c2b23e0000000085de7fbf9dea023d0000008000000080c60299be13c2b23ec60299be13c2b23e9a729fbe2c3b34bd0000000085de7fbf89ea023d00000080000000806de2a5beded0dfbec60299be13c2b23e6de2a5beded0dfbe00000000e70ca2bc2ef37fbf00000000000000806de2a5beded0dfbe6de2a5beded0dfbec002993e2c3b34bd000000008fe07f3f09bafd3c0000008000000080ec92923ee631b93e93729f3eb140e6be93729f3eb140e6be00000000b40ca2bc2ef37fbf000000000000008093729f3eb140e6be93729f3eb140e6beec92923ee631b93e000000008fe07f3f30bafd3c0000008000000080ec92923ee631b93eec92923ee631b93e40fbcdbbfcf9b53e00000000aaf8afbce0f07f3f0000008000000080c60299be13c2b23eec92923ee631b93e40fbcdbbc808e3be00000000e70ca2bc2ef37fbf000000000000008093729f3eb140e6be6de2a5beded0dfbec60299be13c2b23e0000000073f8afbce0f07f3f0000008000000080c60299be13c2b23ec60299be13c2b23e9a729fbe2c3b34bd0000000085de7fbf9dea023d00000080000000806de2a5beded0dfbec60299be13c2b23e6de2a5beded0dfbe0000000085de7fbf89ea023d00000080000000806de2a5beded0dfbe6de2a5beded0dfbe
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -0.006286055, y: -0.044001743, z: 0}
+    m_Extent: {x: 0.31770706, y: 0.40571058, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1725891490
 GameObject:
   m_ObjectHideFlags: 0
@@ -2013,170 +2177,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1788632988}
   m_CullTransparentMesh: 1
---- !u!43 &1894781401
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: -0.006286055, y: -0.044001743, z: 0}
-      m_Extent: {x: 0.31770706, y: 0.40571058, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010003000500040003000600050006000300070002000800000000000900030001000a00020004000b00010003000c00070005000d00040006000e00050007000f000600
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 93729f3eb140e6be000000008fe07f3f09bafd3c000000800000008093729f3eb140e6be93729f3eb140e6beec92923ee631b93e00000000aaf8afbce0f07f3f0000008000000080ec92923ee631b93eec92923ee631b93ec002993e2c3b34bd000000008fe07f3f30bafd3c0000008000000080ec92923ee631b93e93729f3eb140e6be40fbcdbbc808e3be00000000b40ca2bc2ef37fbf000000000000008093729f3eb140e6be6de2a5beded0dfbe40fbcdbbfcf9b53e0000000073f8afbce0f07f3f0000008000000080c60299be13c2b23eec92923ee631b93ec60299be13c2b23e0000000085de7fbf9dea023d0000008000000080c60299be13c2b23ec60299be13c2b23e9a729fbe2c3b34bd0000000085de7fbf89ea023d00000080000000806de2a5beded0dfbec60299be13c2b23e6de2a5beded0dfbe00000000e70ca2bc2ef37fbf00000000000000806de2a5beded0dfbe6de2a5beded0dfbec002993e2c3b34bd000000008fe07f3f09bafd3c0000008000000080ec92923ee631b93e93729f3eb140e6be93729f3eb140e6be00000000b40ca2bc2ef37fbf000000000000008093729f3eb140e6be93729f3eb140e6beec92923ee631b93e000000008fe07f3f30bafd3c0000008000000080ec92923ee631b93eec92923ee631b93e40fbcdbbfcf9b53e00000000aaf8afbce0f07f3f0000008000000080c60299be13c2b23eec92923ee631b93e40fbcdbbc808e3be00000000e70ca2bc2ef37fbf000000000000008093729f3eb140e6be6de2a5beded0dfbec60299be13c2b23e0000000073f8afbce0f07f3f0000008000000080c60299be13c2b23ec60299be13c2b23e9a729fbe2c3b34bd0000000085de7fbf9dea023d00000080000000806de2a5beded0dfbec60299be13c2b23e6de2a5beded0dfbe0000000085de7fbf89ea023d00000080000000806de2a5beded0dfbe6de2a5beded0dfbe
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -0.006286055, y: -0.044001743, z: 0}
-    m_Extent: {x: 0.31770706, y: 0.40571058, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &2004650891
 GameObject:
   m_ObjectHideFlags: 0
@@ -2296,60 +2296,3 @@ MonoBehaviour:
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
---- !u!1001 &3903044160535090980
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3903044160499519337, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_Name
-      value: FoodItem
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 7.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3903044160499519348, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0fe9d4f90c7489d49934845d55efd99d, type: 3}


### PR DESCRIPTION
Accidentally left out changes to scene, meaning prefab was left in when game now instantiates one automatically. This meant two food items would exist at the start and keep spawning another 2 when they were destroyed. Enough to say its fixed in this commit.